### PR TITLE
fix: cannot read property map if list is null

### DIFF
--- a/src/app/log-parser/log_parser.ts
+++ b/src/app/log-parser/log_parser.ts
@@ -216,7 +216,7 @@ export class LogParser {
           const pathToInterestingArray = parsingMetadata.GatherFromArray[DataObjectArray].path.slice(1);
           const interestingArray = extractValue(dataParsed, pathToInterestingArray, variables) as Array<any>;
 
-          interestingArray.map((_, interestingArrayIndex) => {
+          interestingArray?.map((_, interestingArrayIndex) => {
             const gatheredResult: any = {};
             const ResolvedArray = extractValue(
               dataParsed,


### PR DESCRIPTION
Running the application locally produces the log "cannot read property map of undefined".  The array null check resolved the problem.