### PR TITLE
Fix typo

### DIFF
--- a/src/windows/overlay/functions/hovereventlistener.ts
+++ b/src/windows/overlay/functions/hovereventlistener.ts
@@ -29,9 +29,9 @@ export const HoverEventListener = (theCard: Element) => {
       const side = cl.getAttribute('data-side') as string;
 
       if (side === 'opp') {
-        overlayElements.CardHint.innerHTML = `Hover over the card to see it's details`;
+        overlayElements.CardHint.innerHTML = `Hover over the card to see its details`;
       } else {
-        overlayElements.CardHintOpp.innerHTML = `Hover over the card to see it's details`;
+        overlayElements.CardHintOpp.innerHTML = `Hover over the card to see its details`;
       }
     });
 

--- a/src/windows/overlay/overlay.html
+++ b/src/windows/overlay/overlay.html
@@ -43,7 +43,7 @@
           <div id="deckNameOpp" class="deckNameBattle"></div>
         </div>
         <div id="OpponentOut" class="DeckOut"></div>
-        <div id="CardHintOpp" class="CardHint">Hover over the card to see it's details</div>
+        <div id="CardHintOpp" class="CardHint">Hover over the card to see its details</div>
       </div>
     </div>
   </body>


### PR DESCRIPTION
This fixes a typo in one of the overlay elements’ hint.